### PR TITLE
--disable-factory is no longer supported by gnome terminal

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -394,7 +394,7 @@ function! s:StartupServerOnly()
                     let cmd .= ' "'.escape(server_cmd, '"').'"'
                 else
                     " gnome-terminal can set WM_WINDOW_ROLE, so xwit can minimize.
-                    let cmd = "gnome-terminal --class \"VIMSERVER\" --disable-factory"
+                    let cmd = "gnome-terminal --class \"VIMSERVER\" "
                                 \ .' --role "syntastic_server"'
                                 \ .' -e "'.escape(server_cmd, '"').'" &'
                 endif


### PR DESCRIPTION
Details:
https://bugzilla.gnome.org/show_bug.cgi?id=707899
https://mail.gnome.org/archives/commits-list/2013-September/msg05584.html
